### PR TITLE
Show edit button when editor language ID is yaml and in GitHub workflows

### DIFF
--- a/VSCodeExtension/package.json
+++ b/VSCodeExtension/package.json
@@ -29,7 +29,7 @@
 		"menus": {
 			"editor/title": [
 				{
-					"when": "resourceExtname == .yml",
+					"when": "editorLangId == yaml && resourcePath =~ /^.*\\.github\\/workflows\\//",
 					"command": "github-action-editor.editAction",
 					"group": "navigation"
 				}


### PR DESCRIPTION
Thank you for the really cool extension!

I noticed that the edit icon wasn't appearing when I was in a `.yaml` file. Thought I'd make a quick contribution to add this. I also added a check to make sure the file is within the `.github/workflows` directory so that it doesn't appear in other yaml files.

Documentation references:
https://code.visualstudio.com/api/extension-guides/command#controlling-when-a-command-shows-up-in-the-command-palette
https://code.visualstudio.com/api/references/when-clause-contexts#available-context-keys

Thanks!